### PR TITLE
feat: implement issues #6, #15, #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ This design allows easy extension by adding new rules to `src/azure_functions_do
 
 ## Requirements
 
-- Python 3.9+
+- **Python 3.9+** (aligned with [Azure Functions Python support](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python#supported-python-versions); deprecation of older versions follows Microsoft’s runtime support — see [Supported Versions & Policy](docs/supported_versions.md))
 - Git
 - (Optional) Azure Functions Core Tools v4+ (`npm i -g azure-functions-core-tools@4`)
 - (Recommended) Unix-like shell or PowerShell for Makefile support

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ See Examples: [v2](../examples/v2/multi-trigger/README.md) | [v1](../examples/v1
 | [Usage Guide](usage.md) | How to run and interpret results |
 | [Rule System](rules.md) | Understand and customize `rules.json` |
 | [Diagnostics Reference](diagnostics.md) | Full list of built-in checks |
+| [Supported Versions & Policy](supported_versions.md) | Python version support and deprecation timeline |
 | [Developer Guide](development.md) | Contribute and extend the CLI |
 | [Release Process](release_process.md) | Versioning and PyPI publishing |
 

--- a/docs/supported_versions.md
+++ b/docs/supported_versions.md
@@ -1,0 +1,23 @@
+# Supported Python Versions and Deprecation Policy
+
+## Current Support
+
+Azure Functions Doctor supports **Python 3.9 and above**, consistent with the [Azure Functions Python runtime support](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python#supported-python-versions).
+
+- **Minimum version**: Python 3.9
+- **Tested / supported**: 3.9, 3.10, 3.11, 3.12 (as reflected in CI and PyPI classifiers)
+
+## Deprecation Policy
+
+- **Alignment with Azure**: Supported Python versions and deprecation timelines follow **Microsoft’s Azure Functions Python runtime support**. When a Python version is no longer supported by the Azure Functions runtime, we will drop support for that version in this tool and update the minimum accordingly.
+- **Python 3.9**: Python 3.9 is approaching end-of-life. We will **drop Python 3.9 support** when Microsoft ends Azure Functions support for Python 3.9. Until then, the tool will continue to support 3.9.
+- **Version checks and docs**: When we change the minimum supported version, we will:
+  - Update `requires-python` in `pyproject.toml`
+  - Update the version check rules in `src/azure_functions_doctor/assets/rules/` (e.g. `check_python_version`)
+  - Update this document and the [README](../README.md) Requirements section
+  - Bump the project version per [Release Process](release_process.md)
+
+## References
+
+- [Azure Functions – Supported Python versions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python#supported-python-versions)
+- [Python release schedule](https://devguide.python.org/versions/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - CLI Usage: usage.md
   - Diagnostics: diagnostics.md
   - Rules: rules.md
+  - Supported Versions: supported_versions.md
   - Handlers: handlers.md
   - Development: development.md
   - API Reference: api.md

--- a/src/azure_functions_doctor/assets/rules/v1.json
+++ b/src/azure_functions_doctor/assets/rules/v1.json
@@ -121,5 +121,22 @@
   "required": false,
     "hint": "Create local.settings.json for local development if needed.",
     "check_order": 7
+  },
+  {
+    "id": "check_func_core_tools_version",
+    "category": "tooling",
+    "section": "tooling",
+    "label": "Azure Functions Core Tools version",
+    "description": "Checks if the Azure Functions Core Tools (func) version meets the minimum required.",
+    "type": "compare_version",
+    "required": false,
+    "condition": {
+      "target": "func_core_tools",
+      "operator": ">=",
+      "value": "4.0"
+    },
+    "hint": "Install or upgrade Azure Functions Core Tools v4 for local development.",
+    "hint_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local#v4",
+    "check_order": 8
   }
 ]

--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -22,11 +22,12 @@
     "category": "project_structure",
     "section": "programming_model",
     "label": "Programming model v2",
-    "description": "Confirms the project appears to use the v2 decorator-based programming model.",
+    "description": "Confirms the project appears to use the v2 decorator-based programming model (AST-based detection).",
     "type": "source_code_contains",
   "required": true,
     "condition": {
-      "keyword": "@app."
+      "keyword": "@app.",
+      "mode": "ast"
     },
     "check_order": 0
   },
@@ -135,6 +136,23 @@
       "target": "func"
     },
     "hint": "Install Azure Functions Core Tools for local development and testing.",
+    "hint_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local#v4",
+    "check_order": 19
+  },
+  {
+    "id": "check_func_core_tools_version",
+    "category": "tooling",
+    "section": "tooling",
+    "label": "Azure Functions Core Tools version",
+    "description": "Checks if the Azure Functions Core Tools (func) version meets the minimum required.",
+    "type": "compare_version",
+    "required": false,
+    "condition": {
+      "target": "func_core_tools",
+      "operator": ">=",
+      "value": "4.0"
+    },
+    "hint": "Install or upgrade Azure Functions Core Tools v4 for local development.",
     "hint_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local#v4",
     "check_order": 20
   },

--- a/src/azure_functions_doctor/handlers.py
+++ b/src/azure_functions_doctor/handlers.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import os
 import re
@@ -6,11 +7,35 @@ import sys
 from pathlib import Path
 from typing import List, Literal, TypedDict, Union
 
+from packaging.version import InvalidVersion
 from packaging.version import parse as parse_version
 
 from azure_functions_doctor.logging_config import get_logger
+from azure_functions_doctor.target_resolver import resolve_target_value
 
 logger = get_logger(__name__)
+
+
+def _source_contains_ast(source: str, identifier: str) -> bool:
+    """Return True if the Python source contains a decorator like @identifier.xxx (e.g. @app.route)."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+
+    def decorator_matches(dec: ast.expr) -> bool:
+        # @app.route() is ast.Call(func=Attribute(...)); @app.route is ast.Attribute
+        node: ast.expr = dec.func if isinstance(dec, ast.Call) else dec
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            return node.value.id == identifier
+        return False
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.ClassDef)) and node.decorator_list:
+            for dec in node.decorator_list:
+                if decorator_matches(dec):
+                    return True
+    return False
 
 
 def _create_result(status: str, detail: str, internal_error: bool = False) -> dict[str, str]:
@@ -53,6 +78,7 @@ class Condition(TypedDict, total=False):
     operator: str
     value: Union[str, int, float]
     keyword: str
+    mode: Literal["string", "ast"]  # for source_code_contains: "string" (default) or "ast"
     jsonpath: str
     targets: list[str]
     patterns: list[str]
@@ -154,6 +180,27 @@ class HandlerRegistry:
                 f"Python {current_version} ({operator}{value})",
             )
 
+        if target == "func_core_tools":
+            raw = resolve_target_value("func_core_tools")
+            if raw in ("not_installed", "timeout", "unknown_error") or raw.startswith("error_"):
+                return _create_result("fail", f"func: {raw}")
+            try:
+                current = parse_version(raw)
+            except InvalidVersion:
+                return _create_result("fail", f"func version unparseable: {raw}")
+            expected = parse_version(str(value))
+            passed = {
+                ">=": current >= expected,
+                "<=": current <= expected,
+                "==": current == expected,
+                ">": current > expected,
+                "<": current < expected,
+            }.get(operator, False)
+            return _create_result(
+                "pass" if passed else "fail",
+                f"func {raw} ({operator}{value})",
+            )
+
         return _create_result("fail", f"Unknown target for version comparison: {target}")
 
     def _handle_env_var_exists(self, rule: Rule, path: Path) -> dict[str, str]:
@@ -217,9 +264,10 @@ class HandlerRegistry:
             return _handle_exception(f"importing module '{import_path_str}'", exc)
 
     def _handle_source_code_contains(self, rule: Rule, path: Path) -> dict[str, str]:
-        """Handle source code keyword search checks."""
+        """Handle source code keyword search checks (string or AST mode)."""
         condition = rule.get("condition", {}) or {}
         keyword = condition.get("keyword")
+        mode = condition.get("mode", "string")
 
         if not isinstance(keyword, str):
             return _create_result("fail", "Missing or invalid 'keyword' in condition")
@@ -227,37 +275,69 @@ class HandlerRegistry:
         excluded_dirs = {".venv", "build", "dist", ".pytest_cache", "__pycache__"}
         found = False
 
-        for py_file in path.rglob("*.py"):
-            if any(part in excluded_dirs for part in py_file.parts):
-                continue
-            try:
-                content = py_file.read_text(encoding="utf-8")
-                if keyword in content:
-                    found = True
-                    break
-            except PermissionError:
-                logger.warning(f"Permission denied reading {py_file}")
-                continue
-            except UnicodeDecodeError:
-                logger.warning(f"Encoding error in {py_file}, trying with errors='ignore'")
+        if mode == "ast":
+            # AST-based: look for decorator Attribute (e.g. @app.xxx) or Name matching keyword
+            # If keyword looks like "@app.", use "app" as the identifier to find
+            ast_identifier = keyword.strip().lstrip("@").rstrip(".")
+            if not ast_identifier:
+                return _create_result("fail", "Invalid 'keyword' for AST mode")
+            for py_file in path.rglob("*.py"):
+                if any(part in excluded_dirs for part in py_file.parts):
+                    continue
                 try:
-                    content = py_file.read_text(encoding="utf-8", errors="ignore")
+                    content = py_file.read_text(encoding="utf-8")
+                    if _source_contains_ast(content, ast_identifier):
+                        found = True
+                        break
+                except PermissionError:
+                    logger.warning(f"Permission denied reading {py_file}")
+                    continue
+                except UnicodeDecodeError:
+                    try:
+                        content = py_file.read_text(encoding="utf-8", errors="ignore")
+                        if _source_contains_ast(content, ast_identifier):
+                            found = True
+                            break
+                    except Exception:
+                        continue
+                except (MemoryError, SyntaxError):
+                    continue
+                except Exception as exc:
+                    logger.debug(f"Skip {py_file} in AST scan: {exc}")
+                    continue
+        else:
+            for py_file in path.rglob("*.py"):
+                if any(part in excluded_dirs for part in py_file.parts):
+                    continue
+                try:
+                    content = py_file.read_text(encoding="utf-8")
                     if keyword in content:
                         found = True
                         break
-                except Exception:
-                    logger.warning(f"Failed to read {py_file} even with error handling")
+                except PermissionError:
+                    logger.warning(f"Permission denied reading {py_file}")
                     continue
-            except MemoryError:
-                logger.error(f"File too large to process: {py_file}")
-                continue
-            except Exception as exc:
-                logger.error(f"Unexpected error reading {py_file}: {exc}")
-                continue
+                except UnicodeDecodeError:
+                    logger.warning(f"Encoding error in {py_file}, trying with errors='ignore'")
+                    try:
+                        content = py_file.read_text(encoding="utf-8", errors="ignore")
+                        if keyword in content:
+                            found = True
+                            break
+                    except Exception:
+                        logger.warning(f"Failed to read {py_file} even with error handling")
+                        continue
+                except MemoryError:
+                    logger.error(f"File too large to process: {py_file}")
+                    continue
+                except Exception as exc:
+                    logger.error(f"Unexpected error reading {py_file}: {exc}")
+                    continue
 
+        detail_suffix = " (AST)" if mode == "ast" else ""
         return _create_result(
             "pass" if found else "fail",
-            f"Keyword '{keyword}' {'found' if found else 'not found'} in source code",
+            f"Keyword '{keyword}' {'found' if found else 'not found'} in source code{detail_suffix}",
         )
 
     def _handle_package_declared(self, rule: Rule, path: Path) -> dict[str, str]:

--- a/src/azure_functions_doctor/schemas/rules.schema.json
+++ b/src/azure_functions_doctor/schemas/rules.schema.json
@@ -83,7 +83,8 @@
           "file": { "type": "string" },
           "jsonpath": { "type": "string" },
           "targets": { "type": "array", "items": { "type": "string" } },
-          "patterns": { "type": "array", "items": { "type": "string" } }
+          "patterns": { "type": "array", "items": { "type": "string" } },
+          "mode": { "type": "string", "enum": ["string", "ast"], "description": "For source_code_contains: 'string' (default) or 'ast' for AST-based detection." }
         }
       },
       "hint": {

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -37,6 +37,60 @@ def test_compare_python_version_fail() -> None:
     assert result["status"] == "fail"
 
 
+def test_compare_func_core_tools_version_pass(monkeypatch: MonkeyPatch) -> None:
+    """Test that the func Core Tools version check passes when version meets minimum."""
+    from azure_functions_doctor import handlers
+
+    monkeypatch.setattr(handlers, "resolve_target_value", lambda t: "4.0.5455" if t == "func_core_tools" else "")
+    rule: Rule = {
+        "type": "compare_version",
+        "condition": {
+            "target": "func_core_tools",
+            "operator": ">=",
+            "value": "4.0",
+        },
+    }
+    result = generic_handler(rule, Path("."))
+    assert result["status"] == "pass"
+    assert "4.0.5455" in result.get("detail", "")
+
+
+def test_compare_func_core_tools_version_fail_not_installed(monkeypatch: MonkeyPatch) -> None:
+    """Test that the func Core Tools version check fails when func is not installed."""
+    from azure_functions_doctor import handlers
+
+    monkeypatch.setattr(handlers, "resolve_target_value", lambda t: "not_installed" if t == "func_core_tools" else "")
+    rule: Rule = {
+        "type": "compare_version",
+        "condition": {
+            "target": "func_core_tools",
+            "operator": ">=",
+            "value": "4.0",
+        },
+    }
+    result = generic_handler(rule, Path("."))
+    assert result["status"] == "fail"
+    assert "not_installed" in result.get("detail", "")
+
+
+def test_compare_func_core_tools_version_fail_old_version(monkeypatch: MonkeyPatch) -> None:
+    """Test that the func Core Tools version check fails when version is below minimum."""
+    from azure_functions_doctor import handlers
+
+    monkeypatch.setattr(handlers, "resolve_target_value", lambda t: "3.0.0" if t == "func_core_tools" else "")
+    rule: Rule = {
+        "type": "compare_version",
+        "condition": {
+            "target": "func_core_tools",
+            "operator": ">=",
+            "value": "4.0",
+        },
+    }
+    result = generic_handler(rule, Path("."))
+    assert result["status"] == "fail"
+    assert "3.0.0" in result.get("detail", "")
+
+
 def test_env_var_exists_pass(monkeypatch: MonkeyPatch) -> None:
     """ "Test that the environment variable check passes when the variable is set."""
     monkeypatch.setenv("MY_ENV_VAR", "true")
@@ -136,6 +190,40 @@ def test_source_code_contains_fail() -> None:
         }
         result = generic_handler(rule, Path(tmpdir))
         assert result["status"] == "fail"
+
+
+def test_source_code_contains_ast_pass() -> None:
+    """Test that AST mode passes when decorator @app.xxx is present in source."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = Path(tmpdir) / "app.py"
+        file_path.write_text(
+            "from azure.functions import FunctionApp\n"
+            "app = FunctionApp()\n\n"
+            "@app.route()\n"
+            "def main(req):\n"
+            "    return 'ok'\n"
+        )
+        rule: Rule = {
+            "type": "source_code_contains",
+            "condition": {"keyword": "@app.", "mode": "ast"},
+        }
+        result = generic_handler(rule, Path(tmpdir))
+        assert result["status"] == "pass"
+        assert "AST" in result.get("detail", "")
+
+
+def test_source_code_contains_ast_fail() -> None:
+    """Test that AST mode fails when keyword appears only in comment (no real decorator)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = Path(tmpdir) / "app.py"
+        file_path.write_text("# We use @app. decorators elsewhere\nx = 1\n")
+        rule: Rule = {
+            "type": "source_code_contains",
+            "condition": {"keyword": "@app.", "mode": "ast"},
+        }
+        result = generic_handler(rule, Path(tmpdir))
+        assert result["status"] == "fail"
+        assert "AST" in result.get("detail", "")
 
 
 def test_unknown_check_type() -> None:


### PR DESCRIPTION
## Summary
Implements the three open issues: #6, #15, #16.

---

### #16: Add rule to check Azure Functions Core Tools version
- `compare_version` handler now supports `target: func_core_tools` (uses existing `target_resolver.resolve_target_value`)
- Added `check_func_core_tools_version` rule (min 4.0, optional) to `v1.json` and `v2.json`
- Unit tests: pass when version >= 4.0, fail when not_installed or old version

---

### #15: AST-based source scan option for `source_code_contains`
- `source_code_contains` supports `condition.mode`: `string` (default) or `ast`
- `_source_contains_ast()` parses Python source and detects `@identifier.xxx` decorators (e.g. `@app.route`)
- `check_programming_model_v2` in v2 rules now uses `mode: ast` for precise detection (no false positives from comments/strings)
- `rules.schema.json`: added optional `mode` in condition
- Unit tests for AST pass/fail

---

### #6: Document Python 3.9 deprecation policy
- **docs/supported_versions.md**: policy aligned with Azure Functions Python runtime support; Python 3.9 deprecation will follow Microsoft's timeline
- **README.md**: Requirements section links to supported versions doc
- **docs/index.md** + **mkdocs.yml**: added Supported Versions to doc overview and nav

---

**Tests**: 46 tests passed (doctor, handler, rule loading, target_resolver, rules_schema).

Made with [Cursor](https://cursor.com)