### PR TITLE
fix: avoid reloading rules in CLI

### DIFF
--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -122,7 +122,7 @@ def doctor(
     # Log diagnostic start
     loaded_rules = doctor.load_rules()
     log_diagnostic_start(str(resolved_path), len(loaded_rules))
-    results = doctor.run_all_checks()
+    results = doctor.run_all_checks(rules=loaded_rules)
 
     # Calculate execution metrics
     end_time = time.time()

--- a/src/azure_functions_doctor/doctor.py
+++ b/src/azure_functions_doctor/doctor.py
@@ -160,8 +160,8 @@ class Doctor:
 
     # Legacy `rules.json` support removed per repository simplification.
 
-    def run_all_checks(self) -> list[SectionResult]:
-        rules = self.load_rules()
+    def run_all_checks(self, rules: Optional[list[Rule]] = None) -> list[SectionResult]:
+        rules = self.load_rules() if rules is None else rules
         if self.profile == "minimal":
             rules = [rule for rule in rules if rule.get("required", True)]
         elif self.profile not in (None, "full"):


### PR DESCRIPTION
Fixes #47

Avoids loading/validating rules twice in the `azure-functions doctor` CLI path by reusing the already-loaded rules list.

Verification:
- ruff check
- mypy
- pytest