### PR TITLE
fix: remove duplicate Typer command registration

### DIFF
--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -24,6 +24,11 @@ console = Console()
 logger = get_logger(__name__)
 
 
+@cli.callback()
+def main() -> None:
+    """Azure Functions Doctor CLI."""
+
+
 def _validate_inputs(path: str, format_type: str, output: Optional[Path]) -> None:
     """Validate CLI inputs before processing."""
     try:
@@ -281,9 +286,6 @@ def doctor(
     if exit_code != 0:
         raise typer.Exit(exit_code)
 
-
-# Explicit command registration (test-friendly)
-cli.command()(doctor)
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
Fixes #48

Removes redundant command registration and keeps `azure-functions doctor ...` working by using a Typer callback (ensures app remains a multi-command group).

Verification:
- ruff check
- mypy
- pytest