### PR TITLE
fix: align Rule.type with package_declared

### DIFF
--- a/src/azure_functions_doctor/handlers.py
+++ b/src/azure_functions_doctor/handlers.py
@@ -117,6 +117,7 @@ class Rule(TypedDict, total=False):
         "path_exists",
         "file_exists",
         "package_installed",
+        "package_declared",
         "source_code_contains",
         "conditional_exists",
         "callable_detection",


### PR DESCRIPTION
Fixes #49

Adds `package_declared` to the `Rule.type` Literal so types reflect the supported handler registry.

Verification:
- ruff check
- mypy
- pytest