### PR TITLE
docs: clarify trust model for custom rules

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -34,9 +34,9 @@ You can override the rule set with a custom file via the CLI option `--rules` or
 Custom rules files are treated as trusted input.
 
 - **Only use rules files from trusted sources.**
-- Some rule types can execute code as part of evaluation. For example, `package_installed` uses `__import__(target)` for the rule's `target`.
+- Some rule types can execute code as part of evaluation. For example, `package_installed` uses `__import__(target)` for the rule's `target`. Importing a module runs its top-level code at import time.
 
-Do not load rules from untrusted paths.
+Do not load rules from untrusted sources.
 
 ---
 


### PR DESCRIPTION
Fixes #50

Turns the single-line warning into an explicit trust model section, making it clear that custom rules should be treated as trusted input.

Verification:
- pytest