### PR TITLE
fix(issue-58): Replace deprecated utcnow() with timezone-aware datetime.now(UTC)

### DIFF
--- a/examples/v1/multi-trigger/timer_trigger_function/__init__.py
+++ b/examples/v1/multi-trigger/timer_trigger_function/__init__.py
@@ -6,7 +6,7 @@ import azure.functions as func
 
 def main(mytimer: func.TimerRequest) -> None:  # noqa: D401
     """Timer trigger logging current UTC time."""
-    utc_now = datetime.datetime.utcnow().isoformat()
+    utc_now = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
     if mytimer.past_due:
         logging.warning("Timer trigger is past due!")
     logging.info("v1 multi-trigger timer fired at %s", utc_now)

--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -1,7 +1,7 @@
 import json
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Optional
 
@@ -155,9 +155,10 @@ def doctor(
                 warning_count += 1  # unknown treated as warning
 
     if format == "json":
+        generated_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         metadata = {
             "tool_version": __version__,
-            "generated_at": f"{datetime.utcnow().isoformat()}Z",
+            "generated_at": generated_at,
             "target_path": str(Path(path).resolve()),
         }
         json_output = {"metadata": metadata, "results": results}


### PR DESCRIPTION
## Summary
Replaces deprecated `datetime.utcnow()` calls with timezone-aware `datetime.now(timezone.utc)` to ensure compatibility with Python 3.12+ and follow modern datetime best practices.

## Changes
- Updated `cli.py` to use `datetime.now(timezone.utc)` instead of `datetime.utcnow()`
- Updated example timer trigger function to use timezone-aware datetime
- Normalized ISO format output to use 'Z' suffix for UTC times consistently

## Testing
- All existing tests pass locally
- Datetime output format remains consistent with previous behavior

Fixes #58