### PR TITLE
ci: run tests on stacked PRs by removing base branch filter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
Fixes #59

This PR removes the base branch filter from the pull_request trigger in the test workflow, allowing CI to run on all pull requests, including stacked PRs.