### PR TITLE
chore: migrate forbid-korean hook to pre-commit stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,4 +31,4 @@ repos:
         entry: bash -c 'if grep -RIl --exclude-dir=.venv --exclude-dir=.git -n "[가-힣]" docs src README.md CHANGELOG.md; then echo "Korean characters detected. Please use English only."; exit 1; fi'
         language: system
         pass_filenames: false
-        stages: [commit]
+        stages: [pre-commit]


### PR DESCRIPTION
Fixes #60