### PR TITLE
chore: align repo consistency settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.6
     hooks:
       - id: ruff-format
       - id: ruff
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: forbid-korean
         name: Forbid Korean Characters
-        entry: bash -c 'if grep -RIl --exclude-dir=.venv --exclude-dir=.git -n "[가-힣]" docs src README.md CONTRIBUTING.md AGENT.md DESIGN.md PRD.md CHANGELOG.md 2>/dev/null; then echo "Korean characters detected. Please use English only."; exit 1; fi'
+        entry: bash -c 'if grep -RIl --exclude-dir=.venv --exclude-dir=.git -n "[가-힣]" docs src README.md CONTRIBUTING.md AGENTS.md DESIGN.md PRD.md CHANGELOG.md 2>/dev/null; then echo "Korean characters detected. Please use English only."; exit 1; fi'
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ New to open source? Here are some good first issues to get started:
 We maintain high code quality standards:
 
 ### Tools We Use
-* **Formatter:** `ruff` - Consistent code formatting
+* **Formatter:** `ruff format` - Consistent code formatting (line-length 100)
 * **Linter:** `ruff` - Fast Python linter
 * **Type checker:** `mypy` - Static type checking
 * **Import sorting:** `ruff` - Consistent import ordering
@@ -121,7 +121,7 @@ We maintain high code quality standards:
 
 ### Before Submitting
 ```bash
-make format      # Format code with ruff
+make format      # Format code with ruff format
 make lint        # Lint with ruff
 make typecheck   # Type check with mypy
 make test        # Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,14 +46,14 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "ruff==0.15.5",
+    "ruff==0.15.6",
     "requests",
     "types-requests",
 ]
 docs = [
     "mkdocs<2.0",
     "mkdocs-material<10.0",
-    "mkdocstrings[python]<1.0",
+    "mkdocstrings[python]<2.0",
 ]
 
 [project.scripts]
@@ -133,7 +133,7 @@ source = ["src/azure_functions_doctor"]
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
-fail_under = 88
+fail_under = 90
 
 [tool.bandit]
 exclude_dirs = ["tests"]


### PR DESCRIPTION
## Summary
- Bump ruff to 0.15.6 in `pyproject.toml` dev dependencies and in pre-commit `ruff-pre-commit` rev.
- Raise coverage `fail_under` from 88 to 90 and update docs dependency to `mkdocstrings[python]<2.0`.
- Update contributing guidance to use `ruff format` wording (keeping line-length 100) and fix forbid-korean hook path from `AGENT.md` to `AGENTS.md`.