### PR TITLE
chore: release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-03-21
+
 ### Added
 
 - Real Azure end-to-end test workflow (`e2e-azure.yml`) deploying to Consumption plan (`koreacentral`)
 - `docs/testing.md` — Real Azure E2E Tests section
+- Extended handler registry coverage tests
 
 ### Changed
 
-- GitHub Actions versions upgraded to Node.js 24 compatible: `checkout@v6`, `setup-python@v6`, `upload-artifact@v7`, `azure/login@v2.3.0`
+- GitHub Actions versions upgraded to Node.js 24 compatible versions
+- Repository consistency fixes (AGENTS.md, .gitignore standardization)
+
+### Fixed
+
+- Correct `AuthLevel.Anonymous` → `ANONYMOUS` and add restart step for function discovery
+- Post-deploy wait and status probe for Consumption cold-start diagnosis
+
 ## [0.16.0] - 2026-03-15
 
 ### Added
@@ -680,4 +690,3 @@ Add SARIF and JUnit output (fe04a752bdfeeadaf08c22bf3dfa36ad6334fc17)
 - initial project setup with CLI, Makefile, docs, and packaging (a39efbd9a2d2b953905b6ce3925badab2b44c117)
 
 - Initial commit (457425ebde591e34042116d1e5f92ac7006a03cd)
-

--- a/src/azure_functions_doctor/__init__.py
+++ b/src/azure_functions_doctor/__init__.py
@@ -3,4 +3,4 @@
 This module initializes the Azure Functions Doctor package and defines the version string.
 """
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,6 +1,6 @@
 """Tests for the public API surface of azure-functions-doctor."""
 
-import azure_functions_doctor
+import azure_functions_doctor  # pyright: ignore[reportMissingImports]
 
 
 class TestAPISurface:
@@ -9,8 +9,8 @@ class TestAPISurface:
     def test_version_is_importable(self) -> None:
         assert hasattr(azure_functions_doctor, "__version__")
 
-    def test_version_is_0_16_0(self) -> None:
-        assert azure_functions_doctor.__version__ == "0.16.0"
+    def test_version_is_0_16_1(self) -> None:
+        assert azure_functions_doctor.__version__ == "0.16.1"  # pyright: ignore[reportUnknownMemberType]
 
     def test_version_is_string(self) -> None:
-        assert isinstance(azure_functions_doctor.__version__, str)
+        assert isinstance(azure_functions_doctor.__version__, str)  # pyright: ignore[reportUnknownMemberType]


### PR DESCRIPTION
## Summary
- bump package version to 0.16.1 and update public API version test
- refresh changelog with the 0.16.1 release notes

## Validation
- make test
- make build