### PR TITLE
fix: fall back to python3 when python is not on PATH

### DIFF
--- a/src/azure_functions_doctor/handlers.py
+++ b/src/azure_functions_doctor/handlers.py
@@ -576,7 +576,11 @@ class HandlerRegistry:
         target = condition.get("target")
         if not target:
             return _create_result("fail", "Missing 'target' for executable_exists")
-        found = shutil.which(target) is not None
+        # Build candidate list: for "python" also try "python3" (macOS/Linux)
+        candidates = [target]
+        if target == "python":
+            candidates.append("python3")
+        found = any(shutil.which(c) is not None for c in candidates)
         if found:
             # Concise style: "<name> detected"
             return _create_result("pass", f"{target} detected")

--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -6,6 +6,8 @@ import tempfile
 from typing import Any, cast
 from unittest.mock import patch
 
+from pytest import MonkeyPatch
+
 from azure_functions_doctor.handlers import HandlerRegistry, Rule
 
 
@@ -1163,6 +1165,84 @@ def test_executable_exists_missing_target() -> None:
     assert result["status"] == "fail"
     assert "Missing 'target'" in result["detail"]
 
+
+def test_executable_exists_python3_fallback(monkeypatch: MonkeyPatch) -> None:
+    """Test python target falls back to python3 when python is not on PATH."""
+    registry = HandlerRegistry()
+    rule: Rule = {
+        "id": "test_python3_fallback",
+        "type": "executable_exists",
+        "condition": {
+            "target": "python",
+        },
+    }
+
+    # Simulate: 'python' not found, 'python3' found
+    def fake_which(name: str) -> str | None:
+        return "/usr/bin/python3" if name == "python3" else None
+
+    monkeypatch.setattr("shutil.which", fake_which)
+    result = registry.handle(rule, Path("."))
+    assert result["status"] == "pass"
+    assert "python detected" in result["detail"]
+
+
+def test_executable_exists_python_no_fallback_needed(monkeypatch: MonkeyPatch) -> None:
+    """Test python target found directly — no fallback triggered."""
+    registry = HandlerRegistry()
+    rule: Rule = {
+        "id": "test_python_direct",
+        "type": "executable_exists",
+        "condition": {
+            "target": "python",
+        },
+    }
+
+    def fake_which(name: str) -> str | None:
+        return "/usr/bin/python" if name == "python" else None
+
+    monkeypatch.setattr("shutil.which", fake_which)
+    result = registry.handle(rule, Path("."))
+    assert result["status"] == "pass"
+    assert "python detected" in result["detail"]
+
+
+def test_executable_exists_python_neither_found(monkeypatch: MonkeyPatch) -> None:
+    """Test python target fails when neither python nor python3 on PATH."""
+    registry = HandlerRegistry()
+    rule: Rule = {
+        "id": "test_python_neither",
+        "type": "executable_exists",
+        "condition": {
+            "target": "python",
+        },
+    }
+
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    result = registry.handle(rule, Path("."))
+    assert result["status"] == "fail"
+    assert "not found" in result["detail"]
+
+
+def test_executable_exists_non_python_no_fallback(monkeypatch: MonkeyPatch) -> None:
+    """Test non-python target does NOT trigger python3 fallback."""
+    registry = HandlerRegistry()
+    rule: Rule = {
+        "id": "test_non_python_no_fallback",
+        "type": "executable_exists",
+        "condition": {
+            "target": "func",
+        },
+    }
+
+    # python3 exists but should NOT be tried for 'func'
+    def fake_which(name: str) -> str | None:
+        return "/usr/bin/python3" if name == "python3" else None
+
+    monkeypatch.setattr("shutil.which", fake_which)
+    result = registry.handle(rule, Path("."))
+    assert result["status"] == "fail"
+    assert "not found" in result["detail"]
 
 def test_callable_detection_found() -> None:
     """Test _handle_callable_detection with pattern found."""


### PR DESCRIPTION
## Summary
- Fix `_handle_executable_exists` to try `python3` as a fallback when `python` is not on PATH (common on macOS/Linux)
- Refactored to use a candidates list approach per Oracle review recommendation
- Dropped unsafe `sys.executable` fallback that changed PATH check semantics

## Changes
- `src/azure_functions_doctor/handlers.py`: Refactored `_handle_executable_exists` to build a candidates list (`[target]`, plus `"python3"` when target is `"python"`) and check with `any(shutil.which(c) ...)`
- `tests/test_handler_registry.py`: Added 4 focused tests with monkeypatched `shutil.which` covering: direct hit, python3 fallback, neither found, and non-python target isolation

## Validation
- All tests pass (334 passed, 2 skipped)
- ruff: All checks passed
- mypy: Success, no issues found

Closes #104