### PR TITLE
docs: standardize section order and fix factual inaccuracies

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,7 @@ sequenceDiagram
         TR-->>HDLR: resolved value
         HDLR-->>DOC: CheckResult
     end
-    DOC-->>CLI: SectionResult[] + pass/fail status
+    DOC-->>CLI: list[SectionResult]
     CLI-->>Dev: formatted output (table/json/sarif/junit)
 ```
 
@@ -108,7 +108,7 @@ The CLI follows a strict exit code contract:
 
 | Exit code | Meaning |
 |---|---|
-| `0` | All checks passed |
+| `0` | No checks failed |
 | `1` | One or more checks failed |
 | `2` | Usage error (bad arguments) |
 


### PR DESCRIPTION
## Summary

Standardize `docs/architecture.md` to match the consistent section structure across all azure-functions repos.

### Changes
- Add **Design Objectives** section (4 principles)
- Move **Module Boundaries** flowchart from end of doc to after Public API Boundary (matching standard order)
- Add **Key Design Decisions** section (5 decisions: JSON rule assets, HandlerRegistry dispatch, exit code contract, string-based profiles, Typer CLI)
- Fix Profile System: "TOML files" → "string selector (`minimal`/`full`)", `--minimal` → `--profile minimal`
- Fix rule asset fields: `check` → `type` + `condition`
- Fix `run_all_checks` return type: result dict → `list[SectionResult]`
- Fix `schemas/` description: remove "output contracts" (only rule schema exists)
- Soften exit code 0 wording, replace hardcoded line reference with method name
- Add **Sources** (MS Learn references) and **See Also** (cross-repo links)

### Verification
- `make check-all`: 332 tests pass, 95.10% coverage, lint/type/security clean
- Oracle design review: ✅ approved
- Oracle post-implementation review: ✅ approved (4 required fixes + 2 optional applied)

Closes #114