### PR TITLE
docs: normalize storage naming rule formatting

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -58,7 +58,7 @@ python3 -m pip install azure-functions-doctor==0.16.2
 
 ## Read these warnings before provisioning
 
-1. Storage account names must be globally unique (lowercase letters and numbers only, 3-24 characters).
+1. Storage account names must be globally unique (lowercase letters and numbers only, 3–24 characters).
 2. Keep all resources in the same Azure region to avoid avoidable latency and provisioning issues.
 3. Local settings do not auto-sync to Azure; use app settings after deployment when needed.
 4. First publish can take a few minutes because Azure performs a remote build for Python dependencies.


### PR DESCRIPTION
## Summary
Normalize storage account naming rule to use en-dash (`3–24`) for consistency with scaffold, openapi, langgraph, and choose-a-plan.md.

Follow-up to #125 / PR #126.