### PR TITLE
feat(rules): warn on native-extension dependencies in requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fix programming-model detection to fail fast on Python v1, mixed-model, and unknown repositories instead of silently treating them as v2
 - add warning for decorated Blueprint aliases that are never registered with `app.register_functions(...)`
 - add `--target-python` override so Python version diagnostics can evaluate the Azure Functions target runtime separately from the local tool runtime (supports `3.10`–`3.14`; `3.14` is currently in Preview)
+- warn on native dependency packages that often need Azure Functions Linux-compatible builds
 
 - bump version to 0.16.3 (f3b801852d3833a2d86ef5e1177231a4d12e362f)
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -38,6 +38,7 @@ Only required failures produce non-zero process exit code.
 - `file_exists`
 - `package_installed`
 - `package_declared`
+- `native_dependency_risk`
 - `source_code_contains`
 - `conditional_exists`
 - `callable_detection`
@@ -144,6 +145,25 @@ Example failing detail:
 
 ```text
 Package 'azure-functions' not declared in requirements.txt
+```
+
+## 7) `check_native_dependency_risk`
+
+- **What it checks:** `requirements.txt` for packages with common native-extension deployment risk.
+- **Why it matters:** These packages are valid, but Azure Functions Python deployments often fail when Linux wheels or system libraries do not match the build environment.
+- **How to fix:** Build against the Azure Functions Linux runtime. Prefer remote build with `func azure functionapp publish --build remote`.
+- **Current package list:** `pyodbc`, `cryptography`, `lxml`, `pillow`, `numpy`, `pandas`, `scipy`, `opencv-python`, `psycopg2`, `grpcio`, `ujson`, `orjson`.
+- **Severity:** Warning only (`required: false`). It never produces a hard failure.
+
+Example warning detail:
+
+```text
+Native dependencies detected: pyodbc, pillow
+These packages depend on platform-specific native libraries.
+Ensure your build environment matches the Azure Functions Linux runtime.
+Recommended: use remote build (`func azure functionapp publish --build remote`).
+- pyodbc: requires unixODBC and a matching wheel
+- pillow: ensure libjpeg/zlib-compatible wheels for Linux deployment
 ```
 
 ## 8) `check_host_json`

--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -129,6 +129,21 @@
     "check_order": 5
   },
   {
+    "id": "check_native_dependency_risk",
+    "category": "dependencies",
+    "section": "python_env",
+    "label": "Native dependency risk",
+    "description": "Warns when requirements.txt includes packages with native extensions that often require platform-matching Linux builds.",
+    "type": "native_dependency_risk",
+    "required": false,
+    "condition": {
+      "file": "requirements.txt"
+    },
+    "hint": "If you deploy native-extension packages, build against the Azure Functions Linux runtime. Prefer remote build with `func azure functionapp publish --build remote`.",
+    "hint_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python#remote-build",
+    "check_order": 6
+  },
+  {
     "id": "check_azure_functions_worker",
     "category": "dependencies",
     "section": "python_env",
@@ -142,7 +157,7 @@
     },
     "hint": "Remove azure-functions-worker from requirements.txt. The Azure Functions platform manages the worker runtime automatically.",
     "hint_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python#managing-dependencies",
-    "check_order": 6
+    "check_order": 7
   },
   {
     "id": "check_host_json",

--- a/src/azure_functions_doctor/handlers.py
+++ b/src/azure_functions_doctor/handlers.py
@@ -31,6 +31,21 @@ _PYTHON_CANDIDATES: dict[str, list[str]] = {
     "python3": ["python3", "python"] + (["py"] if sys.platform == "win32" else []),
 }
 
+NATIVE_DEPENDENCY_PACKAGES: dict[str, str] = {
+    "pyodbc": "requires unixODBC and a matching wheel",
+    "cryptography": "verify OpenSSL-compatible wheels for the target runtime",
+    "lxml": "ensure libxml2/libxslt-compatible wheels for Linux deployment",
+    "pillow": "ensure libjpeg/zlib-compatible wheels for Linux deployment",
+    "numpy": "ensure compiled wheels match the Azure Functions Linux runtime",
+    "pandas": "ensure compiled wheels match the Azure Functions Linux runtime",
+    "scipy": "ensure compiled wheels match the Azure Functions Linux runtime",
+    "opencv-python": "ensure system-level native libraries match the target runtime",
+    "psycopg2": "consider psycopg2-binary on Azure Functions Consumption plans",
+    "grpcio": "ensure compiled wheels match the Azure Functions Linux runtime",
+    "ujson": "ensure compiled wheels match the Azure Functions Linux runtime",
+    "orjson": "ensure compiled wheels match the Azure Functions Linux runtime",
+}
+
 
 def _discover_functionapp_aliases(source: str) -> set[str]:
     """Extract variable names assigned a ``FunctionApp()`` or ``Blueprint()`` call.
@@ -265,6 +280,48 @@ def _parse_requirements_names(content: str) -> set[str]:
     return names
 
 
+def _detect_native_dependency_risks(content: str) -> list[tuple[str, str]]:
+    """Return matching native-dependency packages in requirements order."""
+    matches: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith(("-r ", "-c ", "--requirement", "--constraint")):
+            continue
+        if line.startswith(("-e ", "--editable")):
+            egg_match = re.search(r"#egg=([^&\s]+)", line)
+            if egg_match:
+                normalized_egg = canonicalize_name(egg_match.group(1))
+                if normalized_egg in NATIVE_DEPENDENCY_PACKAGES and normalized_egg not in seen:
+                    matches.append((normalized_egg, NATIVE_DEPENDENCY_PACKAGES[normalized_egg]))
+                    seen.add(normalized_egg)
+            continue
+        if line.startswith("-"):
+            continue
+        line = line.split("#")[0].strip()
+        if not line:
+            continue
+
+        normalized_name: str | None = None
+        try:
+            req = Requirement(line)
+            normalized_name = canonicalize_name(req.name)
+        except InvalidRequirement:
+            fallback_name = re.split(r"[=<>!~;\[\]@]", line, maxsplit=1)[0].strip()
+            if fallback_name:
+                normalized_name = canonicalize_name(fallback_name)
+
+        if normalized_name is None or normalized_name in seen:
+            continue
+        if normalized_name in NATIVE_DEPENDENCY_PACKAGES:
+            matches.append((normalized_name, NATIVE_DEPENDENCY_PACKAGES[normalized_name]))
+            seen.add(normalized_name)
+
+    return matches
+
+
 def _create_result(status: str, detail: str, internal_error: bool = False) -> dict[str, str]:
     """Create a standardized result dictionary (status limited to 'pass'/'fail')."""
     res: dict[str, str] = {"status": status, "detail": detail}
@@ -339,6 +396,7 @@ class Rule(TypedDict, total=False):
         "package_forbidden",
         "package_declared",
         "blueprint_registration",
+        "native_dependency_risk",
     ]
     label: str
     category: str
@@ -381,6 +439,7 @@ class HandlerRegistry:
             "host_json_extension_bundle_version": self._handle_host_json_extension_bundle_version,
             "package_forbidden": self._handle_package_forbidden,
             "blueprint_registration": self._handle_blueprint_registration,
+            "native_dependency_risk": self._handle_native_dependency_risk,
         }
 
     def handle(
@@ -621,6 +680,37 @@ class HandlerRegistry:
                 "(managed by the platform)",
             )
         return _create_result("pass", f"Package '{package_name}' not declared in {req_file}")
+
+    def _handle_native_dependency_risk(
+        self, rule: Rule, path: Path, context: Optional[RuleContext] = None
+    ) -> dict[str, str]:
+        """Warn when requirements.txt includes packages with native extension risk."""
+        condition = rule.get("condition", {}) or {}
+        req_file_obj = condition.get("file", "requirements.txt")
+        req_file = str(req_file_obj)
+        req_path = path / Path(req_file)
+        if not req_path.exists():
+            return _create_result("pass", f"{req_file} not found; check skipped")
+        try:
+            content = req_path.read_text(encoding="utf-8")
+        except Exception as exc:
+            return _handle_specific_exceptions(f"reading {req_file}", exc)
+
+        matches = _detect_native_dependency_risks(content)
+        if not matches:
+            return _create_result("pass", "No native dependency risk packages declared")
+
+        matched_packages = ", ".join(package for package, _hint in matches)
+        detail_lines = [
+            f"Native dependencies detected: {matched_packages}",
+            "These packages depend on platform-specific native libraries.",
+            "Ensure your build environment matches the Azure Functions Linux runtime.",
+            "Recommended: use remote build (`func azure functionapp publish --build remote`).",
+        ]
+        for package, hint in matches:
+            if hint:
+                detail_lines.append(f"- {package}: {hint}")
+        return _create_result("fail", "\n".join(detail_lines))
 
     def _handle_conditional_exists(
         self, rule: Rule, path: Path, context: Optional[RuleContext] = None

--- a/src/azure_functions_doctor/schemas/rules.schema.json
+++ b/src/azure_functions_doctor/schemas/rules.schema.json
@@ -65,7 +65,8 @@
           "local_settings_security",
           "host_json_extension_bundle_version",
           "package_forbidden",
-          "blueprint_registration"
+          "blueprint_registration",
+          "native_dependency_risk"
         ]
       },
       "required": {

--- a/tests/fixtures/v2/native_deps_present/function_app.py
+++ b/tests/fixtures/v2/native_deps_present/function_app.py
@@ -1,0 +1,22 @@
+from collections.abc import Callable
+from typing import TypeVar
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+class FakeFunctionApp:
+    def route(self, route: str, auth_level: str) -> Callable[[F], F]:
+        _ = (route, auth_level)
+
+        def decorator(func: F) -> F:
+            return func
+
+        return decorator
+
+
+app = FakeFunctionApp()
+
+
+@app.route(route="native-deps", auth_level="anonymous")
+def native_deps() -> str:
+    return "ok"

--- a/tests/fixtures/v2/native_deps_present/host.json
+++ b/tests/fixtures/v2/native_deps_present/host.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/tests/fixtures/v2/native_deps_present/requirements.txt
+++ b/tests/fixtures/v2/native_deps_present/requirements.txt
@@ -1,0 +1,2 @@
+azure-functions
+pyodbc==5.0.0

--- a/tests/fixtures/v2/pure_python_only/function_app.py
+++ b/tests/fixtures/v2/pure_python_only/function_app.py
@@ -1,0 +1,22 @@
+from collections.abc import Callable
+from typing import TypeVar
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+class FakeFunctionApp:
+    def route(self, route: str, auth_level: str) -> Callable[[F], F]:
+        _ = (route, auth_level)
+
+        def decorator(func: F) -> F:
+            return func
+
+        return decorator
+
+
+app = FakeFunctionApp()
+
+
+@app.route(route="pure-python", auth_level="anonymous")
+def pure_python() -> str:
+    return "ok"

--- a/tests/fixtures/v2/pure_python_only/host.json
+++ b/tests/fixtures/v2/pure_python_only/host.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/tests/fixtures/v2/pure_python_only/requirements.txt
+++ b/tests/fixtures/v2/pure_python_only/requirements.txt
@@ -1,0 +1,2 @@
+azure-functions
+requests==2.32.3

--- a/tests/test_native_dependency_risk.py
+++ b/tests/test_native_dependency_risk.py
@@ -1,0 +1,89 @@
+# pyright: reportMissingImports=false
+
+from pathlib import Path
+
+from azure_functions_doctor.doctor import Doctor
+from azure_functions_doctor.handlers import (
+    Rule,
+    _detect_native_dependency_risks,
+    generic_handler,
+)
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "v2"
+
+
+def test_detect_native_dependency_risks_empty_requirements() -> None:
+    assert _detect_native_dependency_risks("") == []
+
+
+def test_detect_native_dependency_risks_pure_python_only() -> None:
+    requirements = "azure-functions\nrequests==2.32.3\n"
+    assert _detect_native_dependency_risks(requirements) == []
+
+
+def test_detect_native_dependency_risks_mixed_packages() -> None:
+    requirements = "azure-functions\npyodbc==5.0.0\npillow>=10\nrequests\n"
+    matches = _detect_native_dependency_risks(requirements)
+    assert [package for package, _hint in matches] == ["pyodbc", "pillow"]
+
+
+def test_detect_native_dependency_risks_handles_comments_and_extras() -> None:
+    requirements = (
+        "# cryptography should be ignored in comments\n"
+        "azure-functions\n"
+        "cryptography[ssh]==44.0.0\n"
+        "orjson==3.10.0  # inline comment\n"
+    )
+    matches = _detect_native_dependency_risks(requirements)
+    assert [package for package, _hint in matches] == ["cryptography", "orjson"]
+
+
+def test_native_dependency_risk_handler_skips_missing_requirements(tmp_path: Path) -> None:
+    rule: Rule = {"type": "native_dependency_risk", "condition": {"file": "requirements.txt"}}
+    result = generic_handler(rule, tmp_path)
+    assert result["status"] == "pass"
+
+
+def test_native_dependency_risk_handler_passes_for_pure_python_requirements(tmp_path: Path) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("azure-functions\nrequests==2.32.3\n", encoding="utf-8")
+    rule: Rule = {"type": "native_dependency_risk", "condition": {"file": "requirements.txt"}}
+    result = generic_handler(rule, tmp_path)
+    assert result["status"] == "pass"
+    assert "No native dependency risk packages declared" in result["detail"]
+
+
+def test_native_dependency_risk_handler_reports_matches_and_hints(tmp_path: Path) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("azure-functions\npyodbc==5.0.0\npsycopg2==2.9.9\n", encoding="utf-8")
+    rule: Rule = {"type": "native_dependency_risk", "condition": {"file": "requirements.txt"}}
+    result = generic_handler(rule, tmp_path)
+    assert result["status"] == "fail"
+    assert "Native dependencies detected: pyodbc, psycopg2" in result["detail"]
+    assert "remote build" in result["detail"]
+    assert "psycopg2-binary" in result["detail"]
+
+
+def test_native_dependency_risk_fixture_warns_in_full_profile() -> None:
+    doctor = Doctor(str(FIXTURES_DIR / "native_deps_present"), profile="full")
+    results = doctor.run_all_checks()
+    item_map = {item["label"]: item for section in results for item in section["items"]}
+
+    assert item_map["Native dependency risk"]["status"] == "warn"
+    assert "pyodbc" in item_map["Native dependency risk"]["value"]
+
+
+def test_native_dependency_risk_fixture_passes_for_pure_python_project() -> None:
+    doctor = Doctor(str(FIXTURES_DIR / "pure_python_only"), profile="full")
+    results = doctor.run_all_checks()
+    item_map = {item["label"]: item for section in results for item in section["items"]}
+
+    assert item_map["Native dependency risk"]["status"] == "pass"
+
+
+def test_native_dependency_risk_rule_filtered_from_minimal_profile() -> None:
+    doctor = Doctor(str(FIXTURES_DIR / "native_deps_present"), profile="minimal")
+    results = doctor.run_all_checks()
+    item_labels = {item["label"] for section in results for item in section["items"]}
+
+    assert "Native dependency risk" not in item_labels


### PR DESCRIPTION
## Summary

Adds `check_native_dependency_risk` (optional, warning-level) that flags packages in `requirements.txt` known to depend on platform-specific native libraries — predictable sources of Azure Functions deployment friction when the build environment doesn't match the Linux Functions worker.

## Detection

Name-matching only via `packaging.utils.canonicalize_name`. Initial list:

```
pyodbc, cryptography, lxml, pillow, numpy, pandas, scipy,
opencv-python, psycopg2, grpcio, ujson, orjson
```

`psycopg2` carries a specific hint recommending `psycopg2-binary` on Consumption plans.

## Behavior

- No `requirements.txt` → silent skip (handled by other rules).
- No risky packages → pass.
- Risky packages found → `warn` (because `required: false`), with a recommendation to use remote build (`func azure functionapp publish --build remote`).
- `--profile minimal` filters it out; `--profile full` shows it.

## Fixtures

- `tests/fixtures/v2/native_deps_present/` → warn
- `tests/fixtures/v2/pure_python_only/` → pass

## Test plan

- Unit tests for the matcher (empty, all-pure, mixed, comments, pinned versions, extras).
- Integration tests against both fixtures.
- `make lint` ✅, `make typecheck` ✅, `make test` ✅ (342 passed, 2 skipped, coverage 93.31%), `make build` ✅.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)