### PR TITLE
chore(ci): standardize Action pinning to immutable SHAs

### DIFF
--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run doctor action on healthy example
         id: doctor
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run doctor action (SARIF format)
         id: doctor-sarif

--- a/.github/workflows/azure-functions-preflight.yml
+++ b/.github/workflows/azure-functions-preflight.yml
@@ -6,6 +6,16 @@
 # Usage:
 #   Copy this file into your repository's .github/workflows/ directory.
 #   Adjust the `working-directory` and Python version as needed.
+#
+# Action pinning exception:
+#   The `uses:` references below are intentionally pinned to floating major
+#   tags (e.g. `@v6`) instead of commit SHAs. This file is distributed as a
+#   copy-paste template for end-user repositories, so SHAs hard-coded here
+#   would go stale immediately on the consumer's side. All workflows that
+#   run as part of this repository's own CI (`ci-test.yml`,
+#   `action-integration.yml`, `e2e-azure.yml`, etc.) follow the
+#   SHA-pinning policy without exception. See CONTRIBUTING.md
+#   § "GitHub Actions Pinning" for the full policy.
 
 name: Azure Functions Pre-flight Check
 
@@ -19,9 +29,11 @@ jobs:
 
     steps:
       - name: Checkout repository
+        # Tag-pinned (not SHA): example workflow exception, see file header.
         uses: actions/checkout@v6
 
       - name: Set up Python
+        # Tag-pinned (not SHA): example workflow exception, see file header.
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.10' && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v5
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -22,7 +22,7 @@ jobs:
       resource_group: ${{ steps.names.outputs.rg }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Compute resource names
         id: names
@@ -37,7 +37,7 @@ jobs:
           echo "st=${ST}"   >> "$GITHUB_OUTPUT"
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
 
@@ -51,7 +51,7 @@ jobs:
             --profile minimal
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3.0.0
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload e2e report
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-report-${{ github.run_id }}-${{ github.run_attempt }}
           path: e2e-report/
@@ -124,7 +124,7 @@ jobs:
     if: always()
     steps:
       - name: Azure login (OIDC)
-        uses: azure/login@v3.0.0
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -54,4 +54,8 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
+        # Exception to the SHA-pinning policy: PyPA's official guidance is to
+        # consume this action via the `release/v1` channel rather than a commit
+        # SHA, so trusted-publisher token issuance keeps working across patch
+        # releases. See CONTRIBUTING.md § "GitHub Actions Pinning" for details.
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@
 - If a CLI option or exit code changes, update docs and tests in the same change.
 - Preserve Python 3.10+ compatibility declared in `pyproject.toml`.
 
+### Action Pinning
+- All external `uses:` references in `.github/workflows/` must be SHA-pinned per `CONTRIBUTING.md` § "GitHub Actions Pinning". The PyPA publish action, local composite actions (`uses: ./...`), and the end-user `azure-functions-preflight.yml` template are the only documented exceptions and must carry an inline comment at the call site.
+
 ## Issue Conventions
 
 Follow these conventions when opening issues so the backlog stays consistent with sibling DX Toolkit repositories.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,72 @@ make cov         # Run tests with coverage
 make check-all   # Run the full local gate
 ```
 
+## GitHub Actions Pinning
+
+All external `uses:` references in `.github/workflows/` MUST pin to a
+full 40-character commit SHA with a trailing comment documenting the
+released version or channel. Example:
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+```
+
+This applies to first-party (`actions/*`, `github/*`, `azure/*`) and
+third-party Actions alike.
+
+**Rationale.** Mutable tags (including immutable-looking version tags
+like `@v6.0.1`) can be retroactively moved by an attacker who gains
+write access to the upstream repository. The
+[`tj-actions/changed-files` compromise (CVE-2025-30066, March 2025)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066)
+demonstrated this exact failure mode: ~23,000 repositories had their CI
+secrets exfiltrated, and only workflows that pinned to a commit SHA were
+safe. GitHub's own guidance now identifies SHA pinning as
+[the only way to use an Action as an immutable release](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions),
+and OpenSSF Scorecard's
+[`Pinned-Dependencies` check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
+flags anything weaker as Medium-risk.
+
+Dependabot updates SHA-pinned references on the configured schedule and
+keeps the trailing version comment in sync, so the human-readable
+context never drifts from the pinned commit.
+
+**Approved exceptions.** The following mutable refs are the only ones
+permitted in this repository and are flagged with an inline comment at
+the call site:
+
+- `pypa/gh-action-pypi-publish@release/v1` — PyPA-maintained stable
+  release channel; this pinning style is explicitly recommended upstream.
+- Local composite actions (`uses: ./...`) — versioned with the repo.
+- `.github/workflows/azure-functions-preflight.yml` — example/template
+  workflow distributed to end-user repositories as a copy-paste
+  pre-deployment health check. Its external `uses:` references are
+  intentionally tag-pinned (`@v6`) so consumers receive a working
+  starting point rather than commit SHAs that would go stale immediately
+  on their side. All workflows that run as part of this repository's
+  own CI (`ci-test.yml`, `action-integration.yml`, `e2e-azure.yml`,
+  etc.) follow the SHA-pinning policy without exception.
+
+When adding a new external Action, resolve the SHA with
+`git ls-remote <repo-url> 'refs/tags/<tag>^{}'`. The trailing `^{}`
+**dereferences** the ref to its target commit; without it, an
+*annotated* tag returns the tag-object SHA instead of the commit SHA,
+and the tag-object SHA is **not** a valid `uses:` target.
+
+```bash
+# Annotated tag — the two forms return *different* SHAs:
+git ls-remote https://github.com/Azure/login 'refs/tags/v3.0.0' 'refs/tags/v3.0.0^{}'
+# 93381592...   refs/tags/v3.0.0       <- tag object, do NOT pin to this
+# 532459ea...   refs/tags/v3.0.0^{}    <- commit, pin to this one
+
+# Lightweight tag — only the non-deref form returns a row, and it is
+# already the commit SHA. Always include the `^{}` form anyway so the
+# same command works for both tag types:
+git ls-remote https://github.com/actions/setup-python 'refs/tags/v6' 'refs/tags/v6^{}'
+```
+
+Single-quote the `refs/...^{}` argument so the `{}` and `^` are not
+interpreted by your shell (notably zsh with `EXTENDED_GLOB`).
+
 ## Example Coverage Policy
 
 Examples are part of the supported API experience and should stay verified.


### PR DESCRIPTION
## Summary

- Pin every external GitHub Action `uses:` reference in `.github/workflows/` to a full 40-character commit SHA with a trailing `# vX.Y.Z` version comment.
- Document the policy and its **three** approved exception classes in `CONTRIBUTING.md` (new "GitHub Actions Pinning" subsection) and add a Working Rules pointer in `AGENTS.md`.
- After this change, **36** external `uses:` refs resolve to an immutable commit SHA, plus **5** documented exceptions (1× `pypa/gh-action-pypi-publish@release/v1`, 2× local composite-action `uses: ./...`, 2× tag-pinned in the user-facing example workflow `azure-functions-preflight.yml`) — **41 `uses:` lines total** across the 13 workflow files. Every exception is flagged with an inline comment at the call site.

Closes #156.

## Why

Mutable version tags (including `@v6`, `@v6.0.1`, `@v3.0.0`, `@v7.0.1`) can be retroactively moved by an attacker who gains write access to the upstream Action repository. The [`tj-actions/changed-files` compromise (CVE-2025-30066, March 2025)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066) demonstrated this exact failure mode: ~23,000 repositories had their CI secrets exfiltrated, and only workflows that pinned to a commit SHA were safe.

- GitHub's own hardening guidance identifies SHA pinning as [the only way to use an Action as an immutable release](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).
- OpenSSF Scorecard's [`Pinned-Dependencies` check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies) flags anything weaker as Medium risk.
- Dependabot already runs weekly for `github-actions` in this repo (`.github/dependabot.yml`) and natively understands the `<sha> # vX.Y.Z` pattern — it bumps the SHA and keeps the trailing version comment in sync, so the human-readable context never drifts from the pinned commit.

This PR is the second sibling propagation of the policy, following:
- canary: [`azure-functions-db-python#146`](https://github.com/yeongseon/azure-functions-db-python/pull/146) (Oracle-reviewed reference text)
- first sibling: [`azure-functions-scaffold-python#125`](https://github.com/yeongseon/azure-functions-scaffold-python/pull/125)

## What changed

| File | Change |
|------|--------|
| `.github/workflows/e2e-azure.yml` | Pin 5 tag refs to SHAs: `actions/checkout@v6`, `actions/setup-python@v6`, `azure/login@v3.0.0` (×2 — `deploy_and_test` and `cleanup` jobs), `actions/upload-artifact@v7.0.1`. |
| `.github/workflows/action-integration.yml` | Pin 2 tag refs to SHAs: `actions/checkout@v6` (×2 — `test-action-action` and `test-action-doctor` jobs). The `uses: ./` self-reference to the local composite action is left as-is (documented exception class — local refs are immutable by virtue of being committed alongside the workflow). |
| `.github/workflows/ci-test.yml` | Fix stale `# v5` comment beside the already-SHA-pinned `codecov/codecov-action@e79a6962...` so it correctly reads `# v6.0.1` (matches the SHA's actual upstream tag — verified via `git ls-remote`). No SHA change. |
| `.github/workflows/publish-pypi.yml` | Add inline exception comment beside `pypa/gh-action-pypi-publish@release/v1` so the rationale is visible at the call site. |
| `.github/workflows/azure-functions-preflight.yml` | Add file-header "Action pinning exception" block documenting why this workflow is the doctor-specific exception, plus per-call-site `# Tag-pinned (not SHA): example workflow exception, see file header.` pointers on the two tag-pinned `uses:` lines. **No SHA changes** — the tag refs are intentionally preserved so the file remains useful as a copy-paste template for end users of `azure-functions-doctor`. |
| `CONTRIBUTING.md` | Add "GitHub Actions Pinning" subsection (policy, rationale, exception list with all three classes, lookup workflow) — adapted from the canonical sibling `azure-functions-db` text, with a third bullet added under "Approved exceptions" calling out `azure-functions-preflight.yml` as the doctor-specific exemption. |
| `AGENTS.md` | Add new `### Action Pinning` Working Rules subsection (parallel structure to existing `### Test Coverage`) pointing to the CONTRIBUTING.md section. |

Workflows already 100% compliant (no edits): `codeql.yml`, `create-release.yml`, `docs.yml`, `maintenance.yml`, `performance.yml`, `sbom.yml`, `security.yml`, `stale.yml`.

## Before / After audit

Total external `uses:` references across all 13 workflows: **41** `uses:` lines (in all states). The table below tracks the SHA pin coverage; documented exceptions (5 total) are unchanged in both states.

| Repo state | SHA-pinned (correct comment) | Tag-pinned (undocumented) | Wrong `# vX` comment |
|------------|-----------------------------:|--------------------------:|---------------------:|
| Before this PR | 29 | 7 | 1 |
| After this PR  | **36** | **0** | **0** |

Documented exceptions (5 total, unchanged):
1. `pypa/gh-action-pypi-publish@release/v1` in `publish-pypi.yml` (universal — per upstream PyPA guidance, this Action only accepts the `release/v1` channel).
2. `uses: ./` ×2 in `action-integration.yml` (universal — local composite-action refs are immutable by virtue of being committed alongside the workflow).
3. `actions/checkout@v6` and `actions/setup-python@v6` in `azure-functions-preflight.yml` (doctor-specific — example/template workflow intended for end-user copy-paste; tag pins keep the file readable and reusable, per Oracle-reviewed design ruling on this PR).

Final state: 36 SHA-pinned + 5 documented exceptions = **41** total.

## SHA provenance

Every new SHA was resolved with `git ls-remote <upstream> 'refs/tags/<tag>^{}'` (dereferenced commit) and matches an existing SHA already in use elsewhere in this repo or in the sibling canary repos (`azure-functions-db`, `azure-functions-scaffold`):

| Ref | SHA | Tag resolved via |
|-----|-----|------------------|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | Matches `refs/tags/v6.0.2`; same SHA already in use in this repo (`ci-test.yml`, `publish-pypi.yml`) and in both canary siblings |
| `actions/setup-python` | `a309ff8b426b58ec0e2a45f0f869d46889d02405` | Matches `refs/tags/v6.0.1`; same SHA already in use in this repo (`ci-test.yml`, `publish-pypi.yml`) and in both canary siblings |
| `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | Matches `refs/tags/v7.0.1`; same SHA already in use in `sbom.yml` |
| `azure/login@v3.0.0` | `532459ea530d8321f2fb9bb10d1e0bcf23869a43` | `git ls-remote https://github.com/Azure/login 'refs/tags/v3.0.0^{}'` (dereferenced commit — `v3.0.0` is an annotated tag, see CONTRIBUTING.md for why `^{}` is required) |
| `codecov/codecov-action` | `e79a6962e0d4c0c17b229090214935d2e33f8354` | Already SHA-pinned; verified as dereferenced commit of `refs/tags/v6.0.1` via `git ls-remote` — the previous `# v5` comment was stale from before the v5→v6 bump |

## Verification

- [x] `grep -hE '^\s*-?\s*uses:' .github/workflows/*.yml | wc -l` returns **41**.
- [x] `grep -hEc 'uses:\s+[^@]+@[0-9a-f]{40}' .github/workflows/*.yml` sums to **36** SHA-pinned refs.
- [x] `grep -hE 'uses:\s+pypa/gh-action-pypi-publish@release/v1' .github/workflows/*.yml | wc -l` returns **1** (PyPA exception).
- [x] `grep -hE 'uses:\s+\./' .github/workflows/*.yml | wc -l` returns **2** (local composite exception in `action-integration.yml`).
- [x] `grep -hEc 'uses:\s+actions/(checkout\|setup-python)@v6\s*$' .github/workflows/azure-functions-preflight.yml` returns **2** (doctor-specific example workflow exception, documented in file header).
- [x] `36 + 1 + 2 + 2 = 41` — every `uses:` line is accounted for under either the SHA policy or a documented exception.
- [x] Both `azure/login@v3.0.0` references in `e2e-azure.yml` (`deploy_and_test` and `cleanup` jobs) resolve to the same commit (`532459ea...`) and preserve the existing OIDC `permissions: id-token: write` block.
- [x] `actions/upload-artifact` is pinned to the same SHA already in use by `sbom.yml`, so no double-version drift exists across workflows.
- [x] `azure-functions-preflight.yml` retains its tag pins **intentionally** (per Oracle-reviewed design ruling on this PR); the file-header block + per-line pointers make the exception self-explanatory for future maintainers and end users copying the template.
- [x] `CONTRIBUTING.md` describes how to resolve a new SHA (`git ls-remote ... 'refs/tags/<tag>^{}'`) with explicit annotated-vs-lightweight-tag handling, so future contributors do not need to ask.
- [x] No LSP diagnostics on any changed `.yml` file.

## Out of scope (tracked separately)

- Dependabot grouping (`groups:`) for `github-actions` — per-PR review is currently preferred so each upstream SHA change can be inspected independently. Will revisit if PR volume becomes painful.
- Other sibling repositories — `azure-functions-validation` and `azure-functions-durable-graph` will follow the same pattern in upcoming PRs; `azure-functions-db#140` (PR #146) and `azure-functions-scaffold#114` (PR #125) already landed as the canary and first sibling propagation.
