### PR TITLE
chore(metadata): align project URLs with canonical -python repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,10 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://yeongseon.github.io/azure-functions-doctor/"
-Documentation = "https://yeongseon.github.io/azure-functions-doctor/"
-Repository = "https://github.com/yeongseon/azure-functions-doctor"
-Issues = "https://github.com/yeongseon/azure-functions-doctor/issues"
+Homepage = "https://yeongseon.github.io/azure-functions-doctor-python/"
+Documentation = "https://yeongseon.github.io/azure-functions-doctor-python/"
+Repository = "https://github.com/yeongseon/azure-functions-doctor-python"
+Issues = "https://github.com/yeongseon/azure-functions-doctor-python/issues"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

- Update `[project.urls]` in `pyproject.toml` to use the canonical `-python` repository slug for `Homepage`, `Documentation`, `Repository`, and `Issues`.
- Stops the package from advertising redirected, pre-rename URLs on PyPI.
- No source or test changes; metadata-only.

Closes #154

## Context

`pyproject.toml` still pointed all four `[project.urls]` keys at the pre-rename slug `yeongseon/azure-functions-doctor`. The actual GitHub repository now lives at `yeongseon/azure-functions-doctor-python`, so each URL was relying on GitHub's automatic redirect for renamed repositories and on a docs hostname that no longer matches the canonical Pages site.

All four sibling repos in the toolkit already use the canonical `-python` slug throughout their `[project.urls]` blocks (scaffold, db, validation, logging — verified on `origin/main`). This PR brings doctor in line.

## What changes

`pyproject.toml` lines 34-37, single hunk, +4 -4:

```diff
 [project.urls]
-Homepage = "https://yeongseon.github.io/azure-functions-doctor/"
-Documentation = "https://yeongseon.github.io/azure-functions-doctor/"
-Repository = "https://github.com/yeongseon/azure-functions-doctor"
-Issues = "https://github.com/yeongseon/azure-functions-doctor/issues"
+Homepage = "https://yeongseon.github.io/azure-functions-doctor-python/"
+Documentation = "https://yeongseon.github.io/azure-functions-doctor-python/"
+Repository = "https://github.com/yeongseon/azure-functions-doctor-python"
+Issues = "https://github.com/yeongseon/azure-functions-doctor-python/issues"
```

## Acceptance criteria mapping (issue #154)

- [x] Update `Homepage` and `Documentation` to the canonical published docs path (`https://yeongseon.github.io/azure-functions-doctor-python/`)
- [x] Update `Repository` to `https://github.com/yeongseon/azure-functions-doctor-python`
- [x] Update `Issues` to `https://github.com/yeongseon/azure-functions-doctor-python/issues`
- [ ] Publish a release containing the corrected metadata — deferred to a follow-up `make release-patch` run after this PR merges (PyPI does not allow re-uploading existing versions, so the corrected metadata first ships in the next published version)

## Out of scope (intentional)

Per the issue's narrowly-scoped Out-of-Scope section and Oracle design review, this PR touches only `pyproject.toml`. The repo rename has also left stale references in several other places, but each of these belongs in a separate fix tracked by its own issue (one PR per issue):

- `.github/workflows/stale.yml` lines 15, 35 — `if: github.repository == 'yeongseon/azure-functions-doctor'` comparison is currently false against the actual slug, so the stale workflow no-ops. Will be filed as a separate `fix(ci): ...` follow-up.
- `.github/ISSUE_TEMPLATE/config.yml` lines 4, 7 — discussions and README URLs use the old slug.
- `.github/ISSUE_TEMPLATE/general_issue.yml` line 13 — discussions URL uses the old slug.
- `README.ja.md`, `README.ko.md` — translated READMEs still link badges and the clone URL to the old slug (the English `README.md` was updated previously).
- `src/azure_functions_doctor/cli.py` line 294 — SARIF `informationUri` field still uses the old slug; this is published tool metadata adjacent to but not part of the package metadata fix.

Each of the above will be filed as a separate follow-up issue.

## Verification

Local (Linux, Python 3.10.12, hatch 1.16.5):

```text
$ hatch run lint
All checks passed!                                       # ruff
Success: no issues found in 33 source files              # mypy

$ hatch run test
380 passed, 2 skipped in 4.95s
Required test coverage of 95.0% reached. Total coverage: 95.89%

$ hatch build
dist/azure_functions_doctor-0.17.1.tar.gz
dist/azure_functions_doctor-0.17.1-py3-none-any.whl
```

Metadata-specific verification (Oracle review Q5) — inspect built artifacts to confirm canonical `Project-URL` entries are baked into both the wheel `METADATA` and the sdist `PKG-INFO`:

```text
$ unzip -p dist/azure_functions_doctor-0.17.1-py3-none-any.whl '*METADATA' | grep '^Project-URL'
Project-URL: Homepage, https://yeongseon.github.io/azure-functions-doctor-python/
Project-URL: Documentation, https://yeongseon.github.io/azure-functions-doctor-python/
Project-URL: Repository, https://github.com/yeongseon/azure-functions-doctor-python
Project-URL: Issues, https://github.com/yeongseon/azure-functions-doctor-python/issues

$ tar -xzOf dist/azure_functions_doctor-0.17.1.tar.gz --wildcards '*/PKG-INFO' | grep '^Project-URL'
Project-URL: Homepage, https://yeongseon.github.io/azure-functions-doctor-python/
Project-URL: Documentation, https://yeongseon.github.io/azure-functions-doctor-python/
Project-URL: Repository, https://github.com/yeongseon/azure-functions-doctor-python
Project-URL: Issues, https://github.com/yeongseon/azure-functions-doctor-python/issues
```

Reachability check on the canonical URLs:

- `GET https://yeongseon.github.io/azure-functions-doctor-python/` → 200, full mkdocs site renders
- `GET https://github.com/yeongseon/azure-functions-doctor-python` → 200, the actual repo

## Release follow-up

After merge, the user can cut `v0.17.2` from `main` via `make release-patch` (which bumps version, regenerates `CHANGELOG.md` via git-cliff, tags, and triggers the PyPI publish workflow). The corrected URLs first appear on PyPI as part of that release.

## References

- Issue: #154
- Oracle design review: PASS (recommended strict-scope Option E — pyproject.toml only)
- Sibling canonical pattern (all use `-python` suffix throughout `[project.urls]`):
  - https://github.com/yeongseon/azure-functions-scaffold-python/blob/main/pyproject.toml
  - https://github.com/yeongseon/azure-functions-db-python/blob/main/pyproject.toml
  - https://github.com/yeongseon/azure-functions-validation-python/blob/main/pyproject.toml
  - https://github.com/yeongseon/azure-functions-logging-python/blob/main/pyproject.toml
